### PR TITLE
Front elements on critical and diplomatic

### DIFF
--- a/docs/1.0/critical/index.md
+++ b/docs/1.0/critical/index.md
@@ -28,6 +28,7 @@ Document Status: Draft
   * [revisionDesc](#revisiondesc)
 * [Facsimile](#facsimile)
 * [Text](#text)
+  * [Front](#front)
 * [Apparatus Criticus](#apparatus-criticus)
   - [varation](#variation)
   - [correction](#correction)

--- a/docs/1.0/critical/index.md
+++ b/docs/1.0/critical/index.md
@@ -369,10 +369,14 @@ Example using e-codices IIIF canvas id
 
 ## front
 
+### Description
+
+`front` is used to make prefatory declarations about the text. For now that only includes the starting location of the text in the witnesses.
+
 ### Rules
 
-* `front` should take a `div` with the `xml:id="starts-on"`
-  - The content of this div should take only `pb` and `cb` is indicating the page and column on which the text begins.
+* `front` **MUST** take a `div` with the `xml:id="starts-on"`
+  - The content of this div should only be `pb` and `cb` indicating the page and column on which the text begins in the different witnesses.
 
 ### Examples
 

--- a/docs/1.0/diplomatic/index.md
+++ b/docs/1.0/diplomatic/index.md
@@ -290,6 +290,48 @@ NOTE: The rules concerning the `schemaRef` are subject to revision based on the 
 </encodingDesc>
 ```
 
+# text
+
+## Description
+
+`text` is the main wrapper of the edition and sibling to the `teiHeader`
+
+## Rules
+
+* `text` **MUST** take an `@type` attribute the value of which is "diplomatic"
+  - the possible values for `text@type` are "critical", "diplomatic", and "translation"
+* `text` **SHOULD** take an `@xml:lang` attribute indicating the dominant language of the edition, usually `la` for "latin"
+
+## front
+
+### Description
+
+`front` is used to make prefatory declarations about the text. For now that only includes the starting location of the text in the witness.
+
+### Rules
+
+* `front` **MUST** take a `div` with the `xml:id="starts-on"`
+  - The content of this div should only be `pb` and `cb` indicating the page and column on which the text begins in the witness of the edition.
+
+### Examples
+
+```xml
+<front>
+  <div xml:id="starts-on">
+    <pb ed="#V" n="5-r" facs="V5r"/><cb ed="#V" n="b"/> <!-- V5rb -->
+  </div>
+</front>
+```
+
+## body
+
+## div
+
+## head
+
+## p
+
+
 # Editorial Emendations
 
 ## Expansions

--- a/docs/1.0/diplomatic/index.md
+++ b/docs/1.0/diplomatic/index.md
@@ -25,6 +25,8 @@ Document Status: Draft
     * [sourceDesc](#sourcedesc)
   * [revisionDesc](#revisiondesc)
   * [encodingDesc](#encodingdesc)
+* [Text](#text)
+  * [Front](#front)
 * [Editorial Emendations](#editorial-emendations)
   * [Expansions](#expansions)
   * [Corrections](#corrections)


### PR DESCRIPTION
Add `text` and `front` elements to diplomatic

Improve description and rules on front in critical, which includes
- Add a draft description of use of the front element
- Revise the rules to require (**MUST**) the declaration of the
  `div#starts-on` (that is my suggestion).

This should close #44. 


