### PR TITLE
Update encodingDesc

### DIFF
--- a/docs/1.0/critical/index.md
+++ b/docs/1.0/critical/index.md
@@ -238,14 +238,14 @@ NOTE: The rules concerning the `schemaRef` are subject to revision based on the 
 
 ```xml
 <encodingDesc>
- <variantEncoding method="parallel-segmentation"
- location="internal"/> 
- <schemaRef 
-   n="lbp-critical-1.0.0"
-   target="https://raw.githubusercontent.com/lombardpress/lombardpress-schema/master/src/1.0/critical.rng">
-</schemaRef>
-<editorialDecl>
-  <p>Encoding of this text has followed the recommendations of the LombardPress 1.0.0 guidelines for a critical edition</p> 
+  <variantEncoding method="parallel-segmentation"
+    location="internal"/>
+  <schemaRef
+    n="lbp-critical-1.0.0"
+    target="https://raw.githubusercontent.com/lombardpress/lombardpress-schema/master/src/1.0/critical.rng">
+  </schemaRef>
+  <editorialDecl>
+    <p>Encoding of this text has followed the recommendations of the LombardPress 1.0.0 guidelines for a critical edition</p>
   </editorialDecl>
 </encodingDesc>
 ```

--- a/docs/1.0/diplomatic/index.md
+++ b/docs/1.0/diplomatic/index.md
@@ -265,14 +265,16 @@ The individual editor would usually not be responsible for maintaining the `revi
 
 ### Description
 
+In a diplomatic edition the `encodingDesc` only serves to declare which schema the edition should be validated against.
+
 ### Rules
 
-1. `encodingDesc` **MUST** be stated. 
-2. `encodingDesc` **MUST** contain `variantEncoding`.
-3. `variantEncoding` **MUST** contain `@method` which confirms that the method of variant encoding is *parallel-segmentation*.
-4. `encodingDesc` **MUST** contain a `schemaRef`.
-5. `schemaRef` **MUST** contain a `target` that points to the URL of the LBP schema.
-6. `schemaRef` **MUST** contain an `@n` pointing to the version number of the LBP schema.
+1. `encodingDesc` **MUST** be stated.
+2. `encodingDesc` **MAY NOT** contain `variantEncoding`.
+3. `encodingDesc` **MUST** contain a `schemaRef`.
+4. `schemaRef` **MUST** contain a `target` that points to the URL of the LBP schema.
+5. `schemaRef` **MUST** contain an `@n` pointing to the version number of the LBP schema.
+6. `encodingDesc` **MAY** take an `editorialDecl` that contains a `p` with a prose description of the guidelines followed in the preparation of this edition.
 
 NOTE: The rules concerning the `schemaRef` are subject to revision based on the exact implementation in the TEI schema.
 
@@ -280,13 +282,14 @@ NOTE: The rules concerning the `schemaRef` are subject to revision based on the 
 
 ```xml
 <encodingDesc>
- <variantEncoding method="parallel-segmentation"
- location="internal"/> 
- <schemaRef 
-   n="lbp-diplomatic-1.0.0"
-   target="https://raw.githubusercontent.com/lombardpress/lombardpress-schema/master/src/1.0/diplomatic.rng" 
-   type="diplomatic">
-</schemaRef>
+  <schemaRef
+    n="lbp-diplomatic-1.0.0"
+    target="https://raw.githubusercontent.com/lombardpress/lombardpress-schema/master/src/1.0/diplomatic.rng"
+    type="diplomatic">
+  </schemaRef>
+  <editorialDecl>
+    <p>Encoding of this text has followed the recommendations of the LombardPress 1.0.0 guidelines for a critical edition</p>
+  </editorialDecl>
 </encodingDesc>
 ```
 

--- a/docs/1.0/diplomatic/index.md
+++ b/docs/1.0/diplomatic/index.md
@@ -288,7 +288,7 @@ NOTE: The rules concerning the `schemaRef` are subject to revision based on the 
     type="diplomatic">
   </schemaRef>
   <editorialDecl>
-    <p>Encoding of this text has followed the recommendations of the LombardPress 1.0.0 guidelines for a critical edition</p>
+    <p>Encoding of this text has followed the recommendations of the LombardPress 1.0.0 guidelines for a diplomatic edition</p>
   </editorialDecl>
 </encodingDesc>
 ```


### PR DESCRIPTION
Update `encodingDesc` on diplomatic, including:
- Disallow `variantEncoding` in diplomatic editions
- Add short description of the `encodingDesc`.
- Add clause on the possible inclusion of `editorialDecl` and add it to
the example.
- Update indent of the example.

Update indentation in `encodingDesc` example

PS. Sorry for the recurring change to the final line, I am changing my Emacs setting to not do that.
