### PR TITLE
Conjecture example, move the `corr` tag

### DIFF
--- a/docs/1.0/critical/index.md
+++ b/docs/1.0/critical/index.md
@@ -1211,7 +1211,7 @@ The tradition is unambiguous, but the editor deems it useless and prints an emen
 ``` xml
 Utrum fides
 <app>
-  <lem type="conjecture-corrected"><corr>sit</corr></lem>
+  <lem type="conjecture-corrected">sit</lem>
   <rdg wit="#P #V #L">servus</rdg>
 </app>
 acquisita

--- a/docs/1.0/critical/index.md
+++ b/docs/1.0/critical/index.md
@@ -1211,8 +1211,8 @@ The tradition is unambiguous, but the editor deems it useless and prints an emen
 ``` xml
 Utrum fides
 <app>
-  <lem type="conjecture-corrected">sit</lem>
-  <rdg wit="#P #V #L"><corr>servus</corr></rdg>
+  <lem type="conjecture-corrected"><corr>sit</corr></lem>
+  <rdg wit="#P #V #L">servus</rdg>
 </app>
 acquisita
 ```


### PR DESCRIPTION
It was on the attested reading. It has now been removed after some deliberation on the subject.