### PR TITLE
Add possible `seg`-elements to variation-inversion rdg-type

### DIFF
--- a/docs/1.0/critical/index.md
+++ b/docs/1.0/critical/index.md
@@ -548,8 +548,11 @@ est
 3. `rdg` **MUST** have `@type=variation-inversion`.
 4. `rdg` text node **MUST** be present.
 5. `rdg` **MUST** have either `@wit` or `@source`.
+6. `rdg` **MAY** have two `seg`-elements which indicate which elements have been inverted.
 
-#### Example
+#### Example 1
+
+In this simple example the `rdg` only contains two words.
 
 ```xml
 fides non
@@ -560,6 +563,24 @@ fides non
 ```
 
 > 10 bona fides] fides bona *A*
+
+#### Example 2
+
+In this example the `rdg` contains more than two words, and it is therefore necessary to indicate which words have been moved around with the `seg`-element.
+
+```xml
+Ad demonstrationem tria requirantur: subiectum, passio, et
+principium per quod ostenditur passio de subiecto. Ubi est
+<app>
+  <lem>ista tria invenire</lem>
+  <rdg wit="#B">ista tria invenire</rdg>
+  <rdg wit="#O" type="variation-inversion">
+    <seg n="1">invenire</seg>
+    <seg n="2">ista tria</seg>
+  </rdg>
+</app>
+, ibi contingit ponere scientiam.
+```
 
 ### `variation-present`
 

--- a/src/1.0/critical.xml
+++ b/src/1.0/critical.xml
@@ -31,7 +31,9 @@
               - @ident is required; it is allowed to be any name.
               - @start says what element(s) are allowed as the root element
                   of documents conforming to this schema.  -->
-      <schemaSpec ident="lombardpress-schema" start="TEI">
+      <schemaSpec ident="lombardpress-schema" start="TEI"
+                  source="http://www.tei-c.org/Vault/P5/3.0.0/xml/tei/odd/p5subset.xml">
+
       	<!-- Core Module -->
       	<moduleRef key="core"/>
       	


### PR DESCRIPTION
Just a suggestion. It is based on the principle from [correction-transposition](https://github.com/lombardpress/lombardpress-schema/blob/develop/docs/1.0/critical/index.md#correction-transposition)

This is used to indicate which words have been inverted when more than
two words are involved.

EDIT: Dang! I just see that I also had the commit wit the build version. That's a mistake. Sorry about that!
