### PR TITLE
Add Emacs configuration file for the style guide

### DIFF
--- a/helpers/lbp-emacs-specs.el
+++ b/helpers/lbp-emacs-specs.el
@@ -1,0 +1,12 @@
+(require 'nxml-mode)
+
+(defun lbp-setup ()
+  ;; Required settings for style guide compliance
+  (setq indent-tabs-mode nil)
+  (setq nxml-child-indent 2)
+  (setq nxml-attribute-indent 2)
+
+  ;; Optional settings
+  (setq nxml-slash-auto-complete-flag t))
+
+(add-hook 'nxml-mode-hook 'lbp-setup)


### PR DESCRIPTION
This will (almost) only make sure that the indent value and distance is
correct, as that is the only editor dependent style requirement we have
for now.

When this is merged, I will add a short note to the wiki about how to use it in Emacs... 
I am still contemplating a more extensive guide with suggestions for how Emacs could be set up and used for editing XML.