### PR TITLE
Bugfix/corrections

### DIFF
--- a/docs/critical.md
+++ b/docs/critical.md
@@ -1027,7 +1027,7 @@ It is true that with something like
     <subst>
       <del>insidia</del>
       <add>insidias</add>
-    <subst>
+    </subst>
   </rdg>
 </app>
 ```  
@@ -1091,7 +1091,7 @@ est
     <subst hand="#N1">
       <del>insidia</del>
       <add>insidias</add>
-    <subst>
+    </subst>
   </rdg>
 </app>
 ```
@@ -1440,7 +1440,7 @@ dicit Aristoteles
 
 > 10 cum ] *ABC*, *del.* James
 
-### `conjecture-corrected`
+### conjecture-corrected
 
 #### Description
 

--- a/docs/critical.md
+++ b/docs/critical.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title:  "Lombard Press Schema 1.0.0 - Critical Transcription Guidelines"
+title:  "Lombard Press Schema 1.0.1 - Critical Transcription Guidelines"
 date:   2016-07-15
 categories: schema
 ---

--- a/docs/diplomatic.md
+++ b/docs/diplomatic.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title:  "Lombard Press Schema 1.0.0 - Diplomatic Transcription Guidelines"
+title:  "Lombard Press Schema 1.0.1 - Diplomatic Transcription Guidelines"
 date:   2016-07-15
 categories: schema
 ---


### PR DESCRIPTION
The mistakes were reported by Juhana Toivanen.

I suppose this implies a bump to 1.0.1 right? I have bumped the version numbers in the docs, but nowhere else (I think the examples giving 1.0.0 as suggested version number is still good for path level version bumps). Are there other places? The ODD somewhere (I couldn't find any, but did not look too hard either)? 